### PR TITLE
Fix responses

### DIFF
--- a/plumbing/clusters/create_responses.go
+++ b/plumbing/clusters/create_responses.go
@@ -31,8 +31,8 @@ func (o *CreateReader) ReadResponse(response runtime.ClientResponse, consumer ru
 			return nil, err
 		}
 		return result, nil
-	case 403:
-		result := NewCreateForbidden()
+	case 400:
+		result := NewCreateBadRequest()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
 			return nil, err
 		}
@@ -82,31 +82,33 @@ func (o *CreateOK) readResponse(response runtime.ClientResponse, consumer runtim
 	return nil
 }
 
-// NewCreateForbidden creates a CreateForbidden with default headers values
-func NewCreateForbidden() *CreateForbidden {
-	return &CreateForbidden{}
+// NewCreateBadRequest creates a CreateBadRequest with default headers values
+func NewCreateBadRequest() *CreateBadRequest {
+	return &CreateBadRequest{}
 }
 
-/*CreateForbidden handles this case with default header values.
+/*CreateBadRequest handles this case with default header values.
 
-invalid access token
+Error
 */
-type CreateForbidden struct {
-	Payload string
+type CreateBadRequest struct {
+	Payload *models.Error
 }
 
-func (o *CreateForbidden) Error() string {
-	return fmt.Sprintf("[POST /clusters/create][%d] createForbidden  %+v", 403, o.Payload)
+func (o *CreateBadRequest) Error() string {
+	return fmt.Sprintf("[POST /clusters/create][%d] createBadRequest  %+v", 400, o.Payload)
 }
 
-func (o *CreateForbidden) GetPayload() string {
+func (o *CreateBadRequest) GetPayload() *models.Error {
 	return o.Payload
 }
 
-func (o *CreateForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+func (o *CreateBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.Error)
 
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 
@@ -122,12 +124,12 @@ func NewCreateDefault(code int) *CreateDefault {
 
 /*CreateDefault handles this case with default header values.
 
-error
+Default
 */
 type CreateDefault struct {
 	_statusCode int
 
-	Payload *models.Error
+	Payload string
 }
 
 // Code gets the status code for the create default response
@@ -139,16 +141,14 @@ func (o *CreateDefault) Error() string {
 	return fmt.Sprintf("[POST /clusters/create][%d] create default  %+v", o._statusCode, o.Payload)
 }
 
-func (o *CreateDefault) GetPayload() *models.Error {
+func (o *CreateDefault) GetPayload() string {
 	return o.Payload
 }
 
 func (o *CreateDefault) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
-	o.Payload = new(models.Error)
-
 	// response payload
-	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 

--- a/plumbing/clusters/delete_responses.go
+++ b/plumbing/clusters/delete_responses.go
@@ -31,8 +31,8 @@ func (o *DeleteReader) ReadResponse(response runtime.ClientResponse, consumer ru
 			return nil, err
 		}
 		return result, nil
-	case 403:
-		result := NewDeleteForbidden()
+	case 400:
+		result := NewDeleteBadRequest()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
 			return nil, err
 		}
@@ -70,31 +70,33 @@ func (o *DeleteOK) readResponse(response runtime.ClientResponse, consumer runtim
 	return nil
 }
 
-// NewDeleteForbidden creates a DeleteForbidden with default headers values
-func NewDeleteForbidden() *DeleteForbidden {
-	return &DeleteForbidden{}
+// NewDeleteBadRequest creates a DeleteBadRequest with default headers values
+func NewDeleteBadRequest() *DeleteBadRequest {
+	return &DeleteBadRequest{}
 }
 
-/*DeleteForbidden handles this case with default header values.
+/*DeleteBadRequest handles this case with default header values.
 
-invalid access token
+Error
 */
-type DeleteForbidden struct {
-	Payload string
+type DeleteBadRequest struct {
+	Payload *models.Error
 }
 
-func (o *DeleteForbidden) Error() string {
-	return fmt.Sprintf("[POST /clusters/delete][%d] deleteForbidden  %+v", 403, o.Payload)
+func (o *DeleteBadRequest) Error() string {
+	return fmt.Sprintf("[POST /clusters/delete][%d] deleteBadRequest  %+v", 400, o.Payload)
 }
 
-func (o *DeleteForbidden) GetPayload() string {
+func (o *DeleteBadRequest) GetPayload() *models.Error {
 	return o.Payload
 }
 
-func (o *DeleteForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+func (o *DeleteBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.Error)
 
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 
@@ -110,12 +112,12 @@ func NewDeleteDefault(code int) *DeleteDefault {
 
 /*DeleteDefault handles this case with default header values.
 
-error
+Default
 */
 type DeleteDefault struct {
 	_statusCode int
 
-	Payload *models.Error
+	Payload string
 }
 
 // Code gets the status code for the delete default response
@@ -127,16 +129,14 @@ func (o *DeleteDefault) Error() string {
 	return fmt.Sprintf("[POST /clusters/delete][%d] delete default  %+v", o._statusCode, o.Payload)
 }
 
-func (o *DeleteDefault) GetPayload() *models.Error {
+func (o *DeleteDefault) GetPayload() string {
 	return o.Payload
 }
 
 func (o *DeleteDefault) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
-	o.Payload = new(models.Error)
-
 	// response payload
-	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 

--- a/plumbing/clusters/edit_responses.go
+++ b/plumbing/clusters/edit_responses.go
@@ -33,8 +33,8 @@ func (o *EditReader) ReadResponse(response runtime.ClientResponse, consumer runt
 			return nil, err
 		}
 		return result, nil
-	case 403:
-		result := NewEditForbidden()
+	case 400:
+		result := NewEditBadRequest()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
 			return nil, err
 		}
@@ -72,31 +72,33 @@ func (o *EditOK) readResponse(response runtime.ClientResponse, consumer runtime.
 	return nil
 }
 
-// NewEditForbidden creates a EditForbidden with default headers values
-func NewEditForbidden() *EditForbidden {
-	return &EditForbidden{}
+// NewEditBadRequest creates a EditBadRequest with default headers values
+func NewEditBadRequest() *EditBadRequest {
+	return &EditBadRequest{}
 }
 
-/*EditForbidden handles this case with default header values.
+/*EditBadRequest handles this case with default header values.
 
-invalid access token
+Error
 */
-type EditForbidden struct {
-	Payload string
+type EditBadRequest struct {
+	Payload *models.Error
 }
 
-func (o *EditForbidden) Error() string {
-	return fmt.Sprintf("[POST /clusters/edit][%d] editForbidden  %+v", 403, o.Payload)
+func (o *EditBadRequest) Error() string {
+	return fmt.Sprintf("[POST /clusters/edit][%d] editBadRequest  %+v", 400, o.Payload)
 }
 
-func (o *EditForbidden) GetPayload() string {
+func (o *EditBadRequest) GetPayload() *models.Error {
 	return o.Payload
 }
 
-func (o *EditForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+func (o *EditBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.Error)
 
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 
@@ -112,12 +114,12 @@ func NewEditDefault(code int) *EditDefault {
 
 /*EditDefault handles this case with default header values.
 
-error
+Default
 */
 type EditDefault struct {
 	_statusCode int
 
-	Payload *models.Error
+	Payload string
 }
 
 // Code gets the status code for the edit default response
@@ -129,16 +131,14 @@ func (o *EditDefault) Error() string {
 	return fmt.Sprintf("[POST /clusters/edit][%d] edit default  %+v", o._statusCode, o.Payload)
 }
 
-func (o *EditDefault) GetPayload() *models.Error {
+func (o *EditDefault) GetPayload() string {
 	return o.Payload
 }
 
 func (o *EditDefault) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
-	o.Payload = new(models.Error)
-
 	// response payload
-	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 

--- a/plumbing/clusters/get_responses.go
+++ b/plumbing/clusters/get_responses.go
@@ -30,8 +30,8 @@ func (o *GetReader) ReadResponse(response runtime.ClientResponse, consumer runti
 			return nil, err
 		}
 		return result, nil
-	case 403:
-		result := NewGetForbidden()
+	case 400:
+		result := NewGetBadRequest()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
 			return nil, err
 		}
@@ -81,31 +81,33 @@ func (o *GetOK) readResponse(response runtime.ClientResponse, consumer runtime.C
 	return nil
 }
 
-// NewGetForbidden creates a GetForbidden with default headers values
-func NewGetForbidden() *GetForbidden {
-	return &GetForbidden{}
+// NewGetBadRequest creates a GetBadRequest with default headers values
+func NewGetBadRequest() *GetBadRequest {
+	return &GetBadRequest{}
 }
 
-/*GetForbidden handles this case with default header values.
+/*GetBadRequest handles this case with default header values.
 
-invalid access token
+Error
 */
-type GetForbidden struct {
-	Payload string
+type GetBadRequest struct {
+	Payload *models.Error
 }
 
-func (o *GetForbidden) Error() string {
-	return fmt.Sprintf("[GET /clusters/get][%d] getForbidden  %+v", 403, o.Payload)
+func (o *GetBadRequest) Error() string {
+	return fmt.Sprintf("[GET /clusters/get][%d] getBadRequest  %+v", 400, o.Payload)
 }
 
-func (o *GetForbidden) GetPayload() string {
+func (o *GetBadRequest) GetPayload() *models.Error {
 	return o.Payload
 }
 
-func (o *GetForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+func (o *GetBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.Error)
 
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 
@@ -121,12 +123,12 @@ func NewGetDefault(code int) *GetDefault {
 
 /*GetDefault handles this case with default header values.
 
-error
+Default
 */
 type GetDefault struct {
 	_statusCode int
 
-	Payload *models.Error
+	Payload string
 }
 
 // Code gets the status code for the get default response
@@ -138,16 +140,14 @@ func (o *GetDefault) Error() string {
 	return fmt.Sprintf("[GET /clusters/get][%d] get default  %+v", o._statusCode, o.Payload)
 }
 
-func (o *GetDefault) GetPayload() *models.Error {
+func (o *GetDefault) GetPayload() string {
 	return o.Payload
 }
 
 func (o *GetDefault) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
-	o.Payload = new(models.Error)
-
 	// response payload
-	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 

--- a/plumbing/clusters/list_node_types_responses.go
+++ b/plumbing/clusters/list_node_types_responses.go
@@ -30,8 +30,8 @@ func (o *ListNodeTypesReader) ReadResponse(response runtime.ClientResponse, cons
 			return nil, err
 		}
 		return result, nil
-	case 403:
-		result := NewListNodeTypesForbidden()
+	case 400:
+		result := NewListNodeTypesBadRequest()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
 			return nil, err
 		}
@@ -79,31 +79,33 @@ func (o *ListNodeTypesOK) readResponse(response runtime.ClientResponse, consumer
 	return nil
 }
 
-// NewListNodeTypesForbidden creates a ListNodeTypesForbidden with default headers values
-func NewListNodeTypesForbidden() *ListNodeTypesForbidden {
-	return &ListNodeTypesForbidden{}
+// NewListNodeTypesBadRequest creates a ListNodeTypesBadRequest with default headers values
+func NewListNodeTypesBadRequest() *ListNodeTypesBadRequest {
+	return &ListNodeTypesBadRequest{}
 }
 
-/*ListNodeTypesForbidden handles this case with default header values.
+/*ListNodeTypesBadRequest handles this case with default header values.
 
-invalid access token
+Error
 */
-type ListNodeTypesForbidden struct {
-	Payload string
+type ListNodeTypesBadRequest struct {
+	Payload *models.Error
 }
 
-func (o *ListNodeTypesForbidden) Error() string {
-	return fmt.Sprintf("[GET /clusters/list-node-types][%d] listNodeTypesForbidden  %+v", 403, o.Payload)
+func (o *ListNodeTypesBadRequest) Error() string {
+	return fmt.Sprintf("[GET /clusters/list-node-types][%d] listNodeTypesBadRequest  %+v", 400, o.Payload)
 }
 
-func (o *ListNodeTypesForbidden) GetPayload() string {
+func (o *ListNodeTypesBadRequest) GetPayload() *models.Error {
 	return o.Payload
 }
 
-func (o *ListNodeTypesForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+func (o *ListNodeTypesBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.Error)
 
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 
@@ -119,12 +121,12 @@ func NewListNodeTypesDefault(code int) *ListNodeTypesDefault {
 
 /*ListNodeTypesDefault handles this case with default header values.
 
-error
+Default
 */
 type ListNodeTypesDefault struct {
 	_statusCode int
 
-	Payload *models.Error
+	Payload string
 }
 
 // Code gets the status code for the list node types default response
@@ -136,16 +138,14 @@ func (o *ListNodeTypesDefault) Error() string {
 	return fmt.Sprintf("[GET /clusters/list-node-types][%d] listNodeTypes default  %+v", o._statusCode, o.Payload)
 }
 
-func (o *ListNodeTypesDefault) GetPayload() *models.Error {
+func (o *ListNodeTypesDefault) GetPayload() string {
 	return o.Payload
 }
 
 func (o *ListNodeTypesDefault) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
-	o.Payload = new(models.Error)
-
 	// response payload
-	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 

--- a/plumbing/clusters/list_responses.go
+++ b/plumbing/clusters/list_responses.go
@@ -30,8 +30,8 @@ func (o *ListReader) ReadResponse(response runtime.ClientResponse, consumer runt
 			return nil, err
 		}
 		return result, nil
-	case 403:
-		result := NewListForbidden()
+	case 400:
+		result := NewListBadRequest()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
 			return nil, err
 		}
@@ -79,31 +79,33 @@ func (o *ListOK) readResponse(response runtime.ClientResponse, consumer runtime.
 	return nil
 }
 
-// NewListForbidden creates a ListForbidden with default headers values
-func NewListForbidden() *ListForbidden {
-	return &ListForbidden{}
+// NewListBadRequest creates a ListBadRequest with default headers values
+func NewListBadRequest() *ListBadRequest {
+	return &ListBadRequest{}
 }
 
-/*ListForbidden handles this case with default header values.
+/*ListBadRequest handles this case with default header values.
 
-invalid access token
+Error
 */
-type ListForbidden struct {
-	Payload string
+type ListBadRequest struct {
+	Payload *models.Error
 }
 
-func (o *ListForbidden) Error() string {
-	return fmt.Sprintf("[GET /clusters/list][%d] listForbidden  %+v", 403, o.Payload)
+func (o *ListBadRequest) Error() string {
+	return fmt.Sprintf("[GET /clusters/list][%d] listBadRequest  %+v", 400, o.Payload)
 }
 
-func (o *ListForbidden) GetPayload() string {
+func (o *ListBadRequest) GetPayload() *models.Error {
 	return o.Payload
 }
 
-func (o *ListForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+func (o *ListBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.Error)
 
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 
@@ -119,12 +121,12 @@ func NewListDefault(code int) *ListDefault {
 
 /*ListDefault handles this case with default header values.
 
-error
+Default
 */
 type ListDefault struct {
 	_statusCode int
 
-	Payload *models.Error
+	Payload string
 }
 
 // Code gets the status code for the list default response
@@ -136,16 +138,14 @@ func (o *ListDefault) Error() string {
 	return fmt.Sprintf("[GET /clusters/list][%d] list default  %+v", o._statusCode, o.Payload)
 }
 
-func (o *ListDefault) GetPayload() *models.Error {
+func (o *ListDefault) GetPayload() string {
 	return o.Payload
 }
 
 func (o *ListDefault) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
-	o.Payload = new(models.Error)
-
 	// response payload
-	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 

--- a/plumbing/clusters/permanent_delete_responses.go
+++ b/plumbing/clusters/permanent_delete_responses.go
@@ -31,8 +31,8 @@ func (o *PermanentDeleteReader) ReadResponse(response runtime.ClientResponse, co
 			return nil, err
 		}
 		return result, nil
-	case 403:
-		result := NewPermanentDeleteForbidden()
+	case 400:
+		result := NewPermanentDeleteBadRequest()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
 			return nil, err
 		}
@@ -70,31 +70,33 @@ func (o *PermanentDeleteOK) readResponse(response runtime.ClientResponse, consum
 	return nil
 }
 
-// NewPermanentDeleteForbidden creates a PermanentDeleteForbidden with default headers values
-func NewPermanentDeleteForbidden() *PermanentDeleteForbidden {
-	return &PermanentDeleteForbidden{}
+// NewPermanentDeleteBadRequest creates a PermanentDeleteBadRequest with default headers values
+func NewPermanentDeleteBadRequest() *PermanentDeleteBadRequest {
+	return &PermanentDeleteBadRequest{}
 }
 
-/*PermanentDeleteForbidden handles this case with default header values.
+/*PermanentDeleteBadRequest handles this case with default header values.
 
-invalid access token
+Error
 */
-type PermanentDeleteForbidden struct {
-	Payload string
+type PermanentDeleteBadRequest struct {
+	Payload *models.Error
 }
 
-func (o *PermanentDeleteForbidden) Error() string {
-	return fmt.Sprintf("[POST /clusters/permanent-delete][%d] permanentDeleteForbidden  %+v", 403, o.Payload)
+func (o *PermanentDeleteBadRequest) Error() string {
+	return fmt.Sprintf("[POST /clusters/permanent-delete][%d] permanentDeleteBadRequest  %+v", 400, o.Payload)
 }
 
-func (o *PermanentDeleteForbidden) GetPayload() string {
+func (o *PermanentDeleteBadRequest) GetPayload() *models.Error {
 	return o.Payload
 }
 
-func (o *PermanentDeleteForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+func (o *PermanentDeleteBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.Error)
 
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 
@@ -110,12 +112,12 @@ func NewPermanentDeleteDefault(code int) *PermanentDeleteDefault {
 
 /*PermanentDeleteDefault handles this case with default header values.
 
-error
+Default
 */
 type PermanentDeleteDefault struct {
 	_statusCode int
 
-	Payload *models.Error
+	Payload string
 }
 
 // Code gets the status code for the permanent delete default response
@@ -127,16 +129,14 @@ func (o *PermanentDeleteDefault) Error() string {
 	return fmt.Sprintf("[POST /clusters/permanent-delete][%d] permanentDelete default  %+v", o._statusCode, o.Payload)
 }
 
-func (o *PermanentDeleteDefault) GetPayload() *models.Error {
+func (o *PermanentDeleteDefault) GetPayload() string {
 	return o.Payload
 }
 
 func (o *PermanentDeleteDefault) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
-	o.Payload = new(models.Error)
-
 	// response payload
-	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 

--- a/plumbing/clusters/resize_responses.go
+++ b/plumbing/clusters/resize_responses.go
@@ -32,8 +32,8 @@ func (o *ResizeReader) ReadResponse(response runtime.ClientResponse, consumer ru
 			return nil, err
 		}
 		return result, nil
-	case 403:
-		result := NewResizeForbidden()
+	case 400:
+		result := NewResizeBadRequest()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
 			return nil, err
 		}
@@ -71,31 +71,33 @@ func (o *ResizeOK) readResponse(response runtime.ClientResponse, consumer runtim
 	return nil
 }
 
-// NewResizeForbidden creates a ResizeForbidden with default headers values
-func NewResizeForbidden() *ResizeForbidden {
-	return &ResizeForbidden{}
+// NewResizeBadRequest creates a ResizeBadRequest with default headers values
+func NewResizeBadRequest() *ResizeBadRequest {
+	return &ResizeBadRequest{}
 }
 
-/*ResizeForbidden handles this case with default header values.
+/*ResizeBadRequest handles this case with default header values.
 
-invalid access token
+Error
 */
-type ResizeForbidden struct {
-	Payload string
+type ResizeBadRequest struct {
+	Payload *models.Error
 }
 
-func (o *ResizeForbidden) Error() string {
-	return fmt.Sprintf("[POST /clusters/resize][%d] resizeForbidden  %+v", 403, o.Payload)
+func (o *ResizeBadRequest) Error() string {
+	return fmt.Sprintf("[POST /clusters/resize][%d] resizeBadRequest  %+v", 400, o.Payload)
 }
 
-func (o *ResizeForbidden) GetPayload() string {
+func (o *ResizeBadRequest) GetPayload() *models.Error {
 	return o.Payload
 }
 
-func (o *ResizeForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+func (o *ResizeBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.Error)
 
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 
@@ -111,12 +113,12 @@ func NewResizeDefault(code int) *ResizeDefault {
 
 /*ResizeDefault handles this case with default header values.
 
-error
+Default
 */
 type ResizeDefault struct {
 	_statusCode int
 
-	Payload *models.Error
+	Payload string
 }
 
 // Code gets the status code for the resize default response
@@ -128,16 +130,14 @@ func (o *ResizeDefault) Error() string {
 	return fmt.Sprintf("[POST /clusters/resize][%d] resize default  %+v", o._statusCode, o.Payload)
 }
 
-func (o *ResizeDefault) GetPayload() *models.Error {
+func (o *ResizeDefault) GetPayload() string {
 	return o.Payload
 }
 
 func (o *ResizeDefault) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
-	o.Payload = new(models.Error)
-
 	// response payload
-	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 

--- a/plumbing/clusters/restart_responses.go
+++ b/plumbing/clusters/restart_responses.go
@@ -31,8 +31,8 @@ func (o *RestartReader) ReadResponse(response runtime.ClientResponse, consumer r
 			return nil, err
 		}
 		return result, nil
-	case 403:
-		result := NewRestartForbidden()
+	case 400:
+		result := NewRestartBadRequest()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
 			return nil, err
 		}
@@ -70,31 +70,33 @@ func (o *RestartOK) readResponse(response runtime.ClientResponse, consumer runti
 	return nil
 }
 
-// NewRestartForbidden creates a RestartForbidden with default headers values
-func NewRestartForbidden() *RestartForbidden {
-	return &RestartForbidden{}
+// NewRestartBadRequest creates a RestartBadRequest with default headers values
+func NewRestartBadRequest() *RestartBadRequest {
+	return &RestartBadRequest{}
 }
 
-/*RestartForbidden handles this case with default header values.
+/*RestartBadRequest handles this case with default header values.
 
-invalid access token
+Error
 */
-type RestartForbidden struct {
-	Payload string
+type RestartBadRequest struct {
+	Payload *models.Error
 }
 
-func (o *RestartForbidden) Error() string {
-	return fmt.Sprintf("[POST /clusters/restart][%d] restartForbidden  %+v", 403, o.Payload)
+func (o *RestartBadRequest) Error() string {
+	return fmt.Sprintf("[POST /clusters/restart][%d] restartBadRequest  %+v", 400, o.Payload)
 }
 
-func (o *RestartForbidden) GetPayload() string {
+func (o *RestartBadRequest) GetPayload() *models.Error {
 	return o.Payload
 }
 
-func (o *RestartForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+func (o *RestartBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.Error)
 
 	// response payload
-	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 
@@ -110,12 +112,12 @@ func NewRestartDefault(code int) *RestartDefault {
 
 /*RestartDefault handles this case with default header values.
 
-error
+Default
 */
 type RestartDefault struct {
 	_statusCode int
 
-	Payload *models.Error
+	Payload string
 }
 
 // Code gets the status code for the restart default response
@@ -127,16 +129,14 @@ func (o *RestartDefault) Error() string {
 	return fmt.Sprintf("[POST /clusters/restart][%d] restart default  %+v", o._statusCode, o.Payload)
 }
 
-func (o *RestartDefault) GetPayload() *models.Error {
+func (o *RestartDefault) GetPayload() string {
 	return o.Payload
 }
 
 func (o *RestartDefault) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
-	o.Payload = new(models.Error)
-
 	// response payload
-	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
 		return err
 	}
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -17,13 +17,9 @@ produces:
 
 responses:
   Error:
-    description: error
+    description: Error
     schema:
       $ref: '#/definitions/Error'
-  InvalidAccessToken:
-    description: invalid access token
-    schema:
-      type: string
 
 securityDefinitions:
   token:
@@ -53,10 +49,12 @@ paths:
             properties:
               cluster_id:
                 type: string
-        403:
-          $ref: '#/responses/InvalidAccessToken'
-        default:
+        400:
           $ref: '#/responses/Error'
+        default:
+          description: Default
+          schema:
+            type: string
 
   /clusters/get:
     get:
@@ -72,10 +70,12 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/ClusterInfo'
-        403:
-          $ref: '#/responses/InvalidAccessToken'
-        default:
+        400:
           $ref: '#/responses/Error'
+        default:
+          description: Default
+          schema:
+            type: string
 
   /clusters/edit:
     post:
@@ -132,10 +132,12 @@ paths:
       responses:
         200:
           description: OK
-        403:
-          $ref: '#/responses/InvalidAccessToken'
-        default:
+        400:
           $ref: '#/responses/Error'
+        default:
+          description: Default
+          schema:
+            type: string
 
   /clusters/delete:
     post:
@@ -152,10 +154,12 @@ paths:
       responses:
         200:
           description: Terminated
-        403:
-          $ref: '#/responses/InvalidAccessToken'
-        default:
+        400:
           $ref: '#/responses/Error'
+        default:
+          description: Default
+          schema:
+            type: string
 
   /clusters/list:
     get:
@@ -168,10 +172,12 @@ paths:
             type: array
             items:
               $ref: '#/definitions/ClusterInfo'
-        403:
-          $ref: '#/responses/InvalidAccessToken'
-        default:
+        400:
           $ref: '#/responses/Error'
+        default:
+          description: Default
+          schema:
+            type: string
 
   /clusters/permanent-delete:
     post:
@@ -188,10 +194,12 @@ paths:
       responses:
         200:
           description: Deleted
-        403:
-          $ref: '#/responses/InvalidAccessToken'
-        default:
+        400:
           $ref: '#/responses/Error'
+        default:
+          description: Default
+          schema:
+            type: string
 
   /clusters/resize:
     post:
@@ -213,10 +221,12 @@ paths:
       responses:
         200:
           description: OK
-        403:
-          $ref: '#/responses/InvalidAccessToken'
-        default:
+        400:
           $ref: '#/responses/Error'
+        default:
+          description: Default
+          schema:
+            type: string
 
   /clusters/restart:
     post:
@@ -233,10 +243,12 @@ paths:
       responses:
         200:
           description: OK
-        403:
-          $ref: '#/responses/InvalidAccessToken'
-        default:
+        400:
           $ref: '#/responses/Error'
+        default:
+          description: Default
+          schema:
+            type: string
 
   /clusters/list-node-types:
     get:
@@ -249,10 +261,12 @@ paths:
             type: array
             items:
               $ref: '#/definitions/NodeType'
-        403:
-          $ref: '#/responses/InvalidAccessToken'
-        default:
+        400:
           $ref: '#/responses/Error'
+        default:
+          description: Default
+          schema:
+            type: string
 
 definitions:
   AutoScale:


### PR DESCRIPTION
The Terraform provider (and SDK) currently do not return useful error messages for some error codes (non-200), because of attempt to parse the response body of failed requests, which results in JSON decode errors. NOTE: This is work in progress