### PR TITLE
Add `AzureAuth` to porcelain

### DIFF
--- a/porcelain/auth_info.go
+++ b/porcelain/auth_info.go
@@ -1,0 +1,16 @@
+package porcelain
+
+import (
+	"github.com/go-openapi/runtime"
+	"github.com/go-openapi/strfmt"
+)
+
+// AzureAuth provides Azure Databricks auth info writer
+func AzureAuth(token, managementToken, workspaceID string) runtime.ClientAuthInfoWriter {
+	return runtime.ClientAuthInfoWriterFunc(func(r runtime.ClientRequest, _ strfmt.Registry) error {
+		r.SetHeaderParam("Authorization", "Bearer "+token)
+		r.SetHeaderParam("X-Databricks-Azure-SP-Management-Token", managementToken)
+		r.SetHeaderParam("X-Databricks-Azure-Workspace-Resource-Id", workspaceID)
+		return nil
+	})
+}

--- a/porcelain/auth_info.go
+++ b/porcelain/auth_info.go
@@ -5,6 +5,10 @@ import (
 	"github.com/go-openapi/strfmt"
 )
 
+const (
+	AzureDatabricksApplicationID = "2ff814a6-3304-4ab8-85cb-cd0e6f879c1d"
+)
+
 // AzureAuth provides Azure Databricks auth info writer
 func AzureAuth(token, managementToken, workspaceID string) runtime.ClientAuthInfoWriter {
 	return runtime.ClientAuthInfoWriterFunc(func(r runtime.ClientRequest, _ strfmt.Registry) error {


### PR DESCRIPTION
Provides Azure Databricks auth info writer.

Note: This is work in progress