### PR TITLE
Fix errors in groups definitions

### DIFF
--- a/groups.yaml
+++ b/groups.yaml
@@ -122,7 +122,7 @@ components:
     MemberAttributes:
       type: object
       properties:
-        username:
+        user_name:
           type: string
         group_name:
           type: string
@@ -134,8 +134,6 @@ components:
     GroupAttributes:
       type: object
       properties:
-        username:
-          type: string
         group_name:
           type: string
       required:

--- a/groups/models.go
+++ b/groups/models.go
@@ -12,7 +12,6 @@ const fqdn = "github.com/innovationnorway/go-databricks/groups"
 
             // Attributes ...
             type Attributes struct {
-            Username *string `json:"username,omitempty"`
             GroupName *string `json:"group_name,omitempty"`
             }
 
@@ -46,7 +45,7 @@ const fqdn = "github.com/innovationnorway/go-databricks/groups"
 
             // MemberAttributes ...
             type MemberAttributes struct {
-            Username *string `json:"username,omitempty"`
+            UserName *string `json:"user_name,omitempty"`
             GroupName *string `json:"group_name,omitempty"`
             ParentName *string `json:"parent_name,omitempty"`
             }


### PR DESCRIPTION
`user_name`, not `username`